### PR TITLE
Add an '_" prefix to all package import aliases

### DIFF
--- a/pkg/packages/imports.go
+++ b/pkg/packages/imports.go
@@ -64,7 +64,7 @@ func calculateTypeNameAndAlias(in, packagePath string, imports map[string]string
 		tmp[a] = struct{}{}
 	}
 	words := strings.Split(pkgPath, "/")
-	alias := words[len(words)-1]
+	alias := "_" + words[len(words)-1]
 	for i := len(words) - 2; i >= 0; i-- {
 		if _, ok := tmp[alias]; !ok {
 			break
@@ -95,7 +95,7 @@ func (m *Imports) UsePackage(pkgPath string) string {
 		tmp[a] = struct{}{}
 	}
 	words := strings.Split(pkgPath, "/")
-	alias := words[len(words)-1]
+	alias := "_" + words[len(words)-1]
 	for i := len(words) - 2; i >= 0; i-- {
 		if _, ok := tmp[alias]; !ok {
 			break
@@ -137,7 +137,7 @@ func parseTypeDec(s string) (string, string) {
 func isBuiltIn(s string) bool {
 	s = strings.NewReplacer("*", "", "[]", "").Replace(s)
 	switch s {
-	case "bool", "string", "int", "int64", "map[string]string":
+	case "range", "bool", "string", "int", "int64", "map[string]string":
 		return true
 	}
 	return false


### PR DESCRIPTION
If the package dirname conflicts with a go reserved keyword, the code generation will fail with syntax errors. An example of this is a package dirname of 'range'.

The import line becomes:

    range "github.com/linode/provider-linode/internal/controller/ipv6_range/range

Which fails with a syntax error.

In the `zz_setup.go` generation, for example, the setup function is also called as:

    range.Setup

Also a syntax error.

By prefixing each of the lines with an '_' then no type collision occurs, and the imports work, as they become:

    _range "github.com/linode/provider-linode/internal/controller/ipv6_range/range
    _range.Setup